### PR TITLE
Error with greeting salutation field name.

### DIFF
--- a/CTCTWrapper/Components/EmailCampaigns/EmailCampaign.cs
+++ b/CTCTWrapper/Components/EmailCampaigns/EmailCampaign.cs
@@ -144,7 +144,7 @@ namespace CTCT.Components.EmailCampaigns
         /// <summary>
         /// Gets or sets the greeting.
         /// </summary>
-        [DataMember(Name = "greetings_salutations", EmitDefaultValue = false)]
+        [DataMember(Name = "greeting_salutations", EmitDefaultValue = false)]
         public string GreetingSalutations { get; set; }
         /// <summary>
         /// Greeting name, string representation.


### PR DESCRIPTION
This was causing the JSON to attempt to write a read-only value and fail
to create a campaign when set.

After making this change and re-compiling the .DLL I was able to set the field and create campaigns again.
