### PR TITLE
Adding ClickThroughDetails property

### DIFF
--- a/CTCTWrapper/Components/EmailCampaigns/EmailCampaign.cs
+++ b/CTCTWrapper/Components/EmailCampaigns/EmailCampaign.cs
@@ -203,6 +203,11 @@ namespace CTCT.Components.EmailCampaigns
         [DataMember(Name = "tracking_summary", EmitDefaultValue = false)]
         public TrackingSummary TrackingSummary { get; set; }
         /// <summary>
+        /// Click through details for each link in this email campaign.
+        /// </summary>
+        [DataMember(Name = "click_through_details", EmitDefaultValue=false)]
+        public IList<ClickThroughDetails> ClickThroughDetails { get; set; }
+        /// <summary>
         /// Gets or sets the message footer.
         /// </summary>
         [DataMember(Name = "message_footer")]


### PR DESCRIPTION
This data is available and returned by the REST API but not exposed via the SDK. The ClickThroughDetails class actually already existed, so it was a simple matter of adding the property to the SDK.

There is no way to test this with the SDK as it would require an existing EmailCampaign that has links as part of it. I was unsuccessful at creating an EmailCampaign with a link in it for testing. I did run a "unit test" that I created that used data in my test Constant Contact account. The new ClickThroughData property was successfully and correctly deserialized.
