### PR TITLE
Added exception when trying to update contact with no ID to prevent HTTP 405 errors.

### DIFF
--- a/CTCTWrapper/Services/ContactService.cs
+++ b/CTCTWrapper/Services/ContactService.cs
@@ -195,6 +195,10 @@ namespace CTCT.Services
         public Contact UpdateContact(string accessToken, string apiKey, Contact contact, bool actionByVisitor)
         {
             Contact updateContact = null;
+            if (contact.Id == null)
+            {
+                throw new CtctException(Config.Errors.UpdateId);
+            }
             string url = String.Concat(Config.Endpoints.BaseUrl, String.Format(Config.Endpoints.Contact, contact.Id), actionByVisitor ? String.Format("?action_by={0}", ActionBy.ActionByVisitor) : null);
             string json = contact.ToJSON();
             CUrlResponse response = RestClient.Put(url, accessToken, apiKey, json);

--- a/CTCTWrapper/Util/Config.cs
+++ b/CTCTWrapper/Util/Config.cs
@@ -351,6 +351,10 @@ namespace CTCT.Util
             /// EmailCampaign or id error.
             /// </summary>
             public const string EmailCampaignOrId = "Only an interger or EmailCampaign are allowed for this method.";
+            /// <summary>
+            /// Update contact without ID error.
+            /// </summary>
+            public const string UpdateId = "You must provide a contact ID in order to update a contact.";
         }
 
         /// <summary>


### PR DESCRIPTION
UpdateContact would allow you to execute with no ID, resulting in a PUT
request to the contacts collection and a method not allowed error
returned from the API. Added an exception that is thrown when a contact
update is sent with no ID.

-Elijah G.
