### PR TITLE
Fixed issue with Stream not closed properly in .NET 3.5

### DIFF
--- a/CTCTWrapper/Util/RestClient.cs
+++ b/CTCTWrapper/Util/RestClient.cs
@@ -90,7 +90,10 @@ namespace CTCT.Util
             {
                 // Convert the request contents to a byte array and include it
                 byte[] requestBodyBytes = System.Text.Encoding.UTF8.GetBytes(data);
-                request.GetRequestStream().Write(requestBodyBytes, 0, requestBodyBytes.Length);
+                using (var stream = request.GetRequestStream())
+                {
+                    stream.Write(requestBodyBytes, 0, requestBodyBytes.Length);
+                }
             }
 
             // Now try to send the request


### PR DESCRIPTION
Solution was provided by a developer on the forums at http://community.constantcontact.com/t5/Getting-Started-with-API-s/System-Enum-does-not-contain-a-definition-for-TryParse/m-p/83011/highlight/false#M1900
