### PR TITLE
Fixed a confusing typo

### DIFF
--- a/CTCTWrapper/Components/Contacts/Contact.cs
+++ b/CTCTWrapper/Components/Contacts/Contact.cs
@@ -152,7 +152,7 @@ namespace CTCT.Components.Contacts
         /// </summary>
         UNCONFIRMED,
         /// <summary>
-        /// Output.
+        /// OptOut.
         /// </summary>
         OPTOUT,
         /// <summary>


### PR DESCRIPTION
I was scratching my  head when I saw this mysterious "Output" status. Might want to consider changing it to avoid confusion.
