### PR TITLE
Fix serializing discounts for promocode

### DIFF
--- a/CTCTWrapper/Components/EventSpot/Promocode.cs
+++ b/CTCTWrapper/Components/EventSpot/Promocode.cs
@@ -50,13 +50,13 @@ namespace CTCT.Components.EventSpot
         /// <summary>
         /// Specifies a fixed discount amount, minimum of 0.01, is required when code_type = DISCOUNT, but not using discount_percent
         /// </summary>
-        [DataMember(Name = "discount_amount", EmitDefaultValue = true)]
+        [DataMember(Name = "discount_amount", EmitDefaultValue = false)]
         public double DiscountAmount { get; set; }
 
         /// <summary>
         /// Specifies a discount percentage, from 1% - 100%, is required when code_type = DISCOUNT, but not using discount_amount
         /// </summary>
-        [DataMember(Name = "discount_percent", EmitDefaultValue = true)]
+        [DataMember(Name = "discount_percent", EmitDefaultValue = false)]
         public int DiscountPercent { get; set; }
 
         /// <summary>

--- a/CTCTWrapper/Components/EventSpot/Registrant.cs
+++ b/CTCTWrapper/Components/EventSpot/Registrant.cs
@@ -100,6 +100,12 @@ namespace CTCT.Components.EventSpot
         public string RegistrationStatus { get; set; }
 
         /// <summary>
+        /// Registration status
+        /// </summary>
+        [DataMember(Name = "attendance_status", EmitDefaultValue = false)]
+        public string AttendanceStatus { get; set; }
+
+        /// <summary>
         /// String representation of update date
         /// </summary>
         [DataMember(Name = "updated_date", EmitDefaultValue = false)]


### PR DESCRIPTION
Promocode class was serializing both discount_amount and
discount_percent regardless of if they were set. This caused 400 error
to be thrown when creating a code because the discount_amount cannot be
set to 0.