### PR TITLE
updating nuget build copy commands

### DIFF
--- a/nuget/nuget.cmd
+++ b/nuget/nuget.cmd
@@ -4,9 +4,9 @@ rd /s /q packages
 
 mkdir packages\lib\net40\
 
-copy ..\CTCTWrapper\bin\Release\CTCTWrapper.dll packages\lib\net40
-copy ..\CTCTWrapper\bin\Release\CTCTWrapper.pdb packages\lib\net40
-copy ..\CTCTWrapper\bin\Release\CTCTWrapper.dll.config packages\lib\net40
+copy ..\CTCTWrapper\bin\Release\CTCT.dll packages\lib\net40
+copy ..\CTCTWrapper\bin\Release\CTCT.pdb packages\lib\net40
+copy ..\CTCTWrapper\bin\Release\CTCT.dll.config packages\lib\net40
 
 nuget.exe update -self
 nuget.exe pack CTCTWrapper.nuspec -Symbols -BasePath packages


### PR DESCRIPTION
I tried pulling down the Nuget but it was empty. I updated the build command to pull down the files needed. Please update the Nuget package at https://www.nuget.org/packages/ConstantContact.NET.SDK/ with this new version of the SDK.