### PR TITLE
Small fix. Unit Test project wouldn't build because of a type mismatch.

### DIFF
--- a/CTCTWrapper/CTCTWrapper.UnitTest/CtctUnitTest.cs
+++ b/CTCTWrapper/CTCTWrapper.UnitTest/CtctUnitTest.cs
@@ -1299,7 +1299,7 @@ namespace CTCTWrapper.UnitTest
             Assert.IsNotNull(contacts.Results);
             Assert.IsTrue(contacts.Results.Count > 0);
 
-            ResultSet<TrackingSummary> result = contactTrackingService.GetEmailCampaignActivities(contacts.Results[0].Id);
+            var result = contactTrackingService.GetEmailCampaignActivities(contacts.Results[0].Id);
             Assert.IsNotNull(result);
         }
 


### PR DESCRIPTION
Using `var` for simplicity. This method was refactored from `ResultSet<>` to `IList<>` in a previous commit but the reference here was never updated.
